### PR TITLE
Ability to stop NavMeshAgent and get Velocity of NavMeshAgent

### DIFF
--- a/Assets/CustomNavMesh/Scripts/CustomNavMeshAgent.cs
+++ b/Assets/CustomNavMesh/Scripts/CustomNavMeshAgent.cs
@@ -131,6 +131,23 @@ public class CustomNavMeshAgent : CustomMonoBehaviour
         set { m_Speed = value; NavMeshAgent.speed = value; onChange?.Invoke(); }
     }
 
+    /// <summary>
+    /// Get current velocity of navmeshagent
+    /// </summary>
+    public Vector3 Velocity
+    {
+        get { return NavMeshAgent.velocity; }
+    }
+
+    /// <summary>
+    /// Stop or resume condition of the navmeshagent
+    /// </summary>
+    public bool IsStopped
+    {
+        get { return NavMeshAgent.isStopped; }
+        set { NavMeshAgent.isStopped = value; onChange?.Invoke(); }
+    }
+
     [SerializeField] float m_Acceleration = 8.0f;
     /// <summary>
     /// The maximum acceleration of an agent as it follows a path, given in units / sec^2.


### PR DESCRIPTION
By using NavMeshAgent's isStopped property, one can change the condition of NavMeshAgent directly. This can be used to e.g. force the agent to stop its movement.
Also implementation of ability to get velocity of the agent.